### PR TITLE
Replace Mimic With Hurricane & Add Hurricane to Gust List

### DIFF
--- a/engine/battle/effect_commands.asm
+++ b/engine/battle/effect_commands.asm
@@ -1736,6 +1736,8 @@ BattleCommand_CheckHit:
 	ret z
 	cp TWISTER
 	ret
+	cp HURRICANE
+	ret
 
 .DigMoves:
 	ld a, BATTLE_VARS_MOVE_ANIM


### PR DESCRIPTION
Forgot to add Hurricane to the list of Gust effects in effect_commands.asm.  Making a second PR to do so.  Here's the text from the original PR:

I implemented Hurricane using Mimic's pointers. However, I only used its move and effect pointers—the battle command pointers remained (I have no clue what'll happen if I decrement pointer lists, and I'm not terribly interested in finding out).

Hurricane follows its Gen 6 iteration: 120 power, 70 accuracy, 10 PP, 30% confusion chance, and always hits in the rain. I also added it to the list of Gust moves, which will hit during the semi-invulnerable turn of Fly and deal double damage.

I increased the confusion chance of Water Pulse to 30% (from 20%). Felt it could use more oomph at 60 power—especially with Bubblebeam at 75, which feels like a genuine tradeoff.

Lastly, I fixed some move descriptions I added because they were clipping in-game.