### PR TITLE
Added Drain Punch and Adjusted Priority Moves

### DIFF
--- a/constants/move_constants.asm
+++ b/constants/move_constants.asm
@@ -257,6 +257,8 @@
 	const ROCK_SMASH   ; f9
 	const WHIRLPOOL    ; fa
 	const BEAT_UP      ; fb
+	const DRAIN_PUNCH  ; fc
+	
 NUM_ATTACKS EQU const_value - 1
 
 ; Battle animations use the same constants as the moves up to this point

--- a/data/moves/animations.asm
+++ b/data/moves/animations.asm
@@ -252,7 +252,7 @@ BattleAnimations::
 	dw BattleAnim_RockSmash
 	dw BattleAnim_Whirlpool
 	dw BattleAnim_BeatUp
-	dw BattleAnim_252
+	dw BattleAnim_DrainPunch
 	dw BattleAnim_253
 	dw BattleAnim_254
 	dw BattleAnim_SweetScent2
@@ -4646,6 +4646,37 @@ BattleAnim_BeatUp:
     anim_obj ANIM_OBJ_01, 144, 64, $0
     anim_wait 12
     anim_ret
+
+BattleAnim_DrainPunch:
+	anim_2gfx ANIM_GFX_CHARGE, ANIM_GFX_HIT
+	anim_call BattleAnim_TargetObj_1Row
+	anim_bgeffect ANIM_BG_1C, $0, $0, $10
+	anim_setvar $0
+.loop
+	anim_sound 6, 3, SFX_WATER_GUN
+	anim_obj ANIM_OBJ_0A, 136, 56, $43
+	anim_obj ANIM_OBJ_ABSORB, 128, 48, $2
+	anim_wait 6
+	anim_sound 6, 3, SFX_WATER_GUN
+	anim_obj ANIM_OBJ_ABSORB, 136, 64, $3
+	anim_wait 6
+	anim_sound 6, 3, SFX_WATER_GUN
+	anim_obj ANIM_OBJ_ABSORB, 136, 32, $4
+	anim_wait 6
+	anim_incvar
+	anim_if_var_equal $7, .done
+	anim_if_var_equal $2, .spawn
+	anim_jump .loop
+
+.spawn
+	anim_obj ANIM_OBJ_3D, 44, 88, $0
+	anim_jump .loop
+
+.done
+	anim_wait 32
+	anim_incbgeffect ANIM_BG_1C
+	anim_call BattleAnim_ShowMon_0
+	anim_ret
 
 BattleAnimSub_Drain:
 	anim_obj ANIM_OBJ_71, 132, 44, $0

--- a/data/moves/descriptions.asm
+++ b/data/moves/descriptions.asm
@@ -251,13 +251,12 @@ MoveDescriptions::
 	dw RockSmashDescription
 	dw WhirlpoolDescription
 	dw BeatUpDescription
-	dw MoveFCDescription
+	dw DrainPunchDescription
 	dw MoveFDDescription
 	dw MoveFEDescription
 	dw MoveFFDescription
 	dw Move00Description
 
-MoveFCDescription:
 MoveFDDescription:
 MoveFEDescription:
 MoveFFDescription:
@@ -1267,3 +1266,7 @@ WhirlpoolDescription:
 BeatUpDescription:
 	db   "A brutalizing"
 	next "physical attack.@"
+
+DrainPunchDescription:
+	db   "Steals 1/2 of the"
+	next "damage inflicted.@"

--- a/data/moves/moves.asm
+++ b/data/moves/moves.asm
@@ -109,7 +109,7 @@ Moves:
 	move HYPNOSIS,     EFFECT_SLEEP,               0, PSYCHIC_TYPE,  70, 20,   0
 	move MEDITATE,     EFFECT_ATTACK_UP,           0, PSYCHIC_TYPE, 100, 40,   0
 	move AGILITY,      EFFECT_SPEED_UP_2,          0, PSYCHIC_TYPE, 100, 30,   0
-	move QUICK_ATTACK, EFFECT_PRIORITY_HIT,       40, NORMAL,       100, 30,   0
+	move QUICK_ATTACK, EFFECT_PRIORITY_HIT,       45, NORMAL,       100, 30,   0
 	move RAGE,         EFFECT_RAGE,               30, NORMAL,       100, 20,   0
 	move TELEPORT,     EFFECT_TELEPORT,            0, PSYCHIC_TYPE, 100, 20,   0
 	move NIGHT_SHADE,  EFFECT_NIGHT_SHADE,        80, GHOST,        100, 10,   0
@@ -194,7 +194,7 @@ Moves:
 	move SPITE,        EFFECT_SPITE,               0, GHOST,        100, 10,   0
 	move POWDER_SNOW,  EFFECT_FREEZE_HIT,         40, ICE,          100, 10,  20
 	move PROTECT,      EFFECT_PROTECT,             0, NORMAL,       100, 10,   0
-	move MACH_PUNCH,   EFFECT_PRIORITY_HIT,       60, FIGHTING,     100, 15,   0
+	move MACH_PUNCH,   EFFECT_PRIORITY_HIT,       40, FIGHTING,     100, 15,   0
 	move SCARY_FACE,   EFFECT_SPEED_DOWN_2,        0, NORMAL,       100, 10,   0
 	move FAINT_ATTACK, EFFECT_ALWAYS_HIT,         60, DARK,         100, 20,   0
 	move SWEET_KISS,   EFFECT_CONFUSE,             0, NORMAL,       100, 10,   0
@@ -209,7 +209,7 @@ Moves:
 	move PERISH_SONG,  EFFECT_PERISH_SONG,         0, NORMAL,       100,  5,   0
 	move ICY_WIND,     EFFECT_SPEED_DOWN_HIT,     55, ICE,           95, 15, 100
 	move DETECT,       EFFECT_PROTECT,             0, FIGHTING,     100, 20,   0
-	move BONE_RUSH,    EFFECT_PRIORITY_HIT,       65, GROUND,        90, 15,   0
+	move BONE_RUSH,    EFFECT_PRIORITY_HIT,       60, GROUND,        90, 15,   0
 	move LOCK_ON,      EFFECT_LOCK_ON,             0, NORMAL,       100,  5,   0
 	move OUTRAGE,      EFFECT_RAMPAGE,           120, DRAGON,       100, 10,   0
 	move SANDSTORM,    EFFECT_SANDSTORM,           0, ROCK,         100, 10,   0
@@ -263,3 +263,4 @@ Moves:
 	move ROCK_SMASH,   EFFECT_DEFENSE_DOWN_HIT,   40, FIGHTING,     100, 10, 100
 	move WHIRLPOOL,    EFFECT_PRIORITY_HIT,       50, WATER,        100, 10,   0
 	move BEAT_UP,      EFFECT_BEAT_UP,            80, DARK,         100, 15,  20
+	move DRAIN_PUNCH,  EFFECT_LEECH_HIT,          60, FIGHTING,     100, 15,   0

--- a/data/moves/names.asm
+++ b/data/moves/names.asm
@@ -250,3 +250,4 @@ MoveNames::
 	db "ROCK SMASH@"
 	db "WHIRLPOOL@"
 	db "BEAT UP@"
+	db "DRAIN PUNCH@"


### PR DESCRIPTION
Added Drain Punch as a net new move (not replacing any existing ones):

- 60 Power
- 100 Accuracy
- 15 PP
- Steals 1/2 damage inflicted
- Uses Fire/Ice/Thunder/Dynamic Punch + Mega Drain animations

Also adjusted the power of priority moves (excluding Extreme Speed) as follows:

- Quick Attack:  40 -> 45
- Bone Rush:  65 -> 60
- Mach Punch:  60 -> 40