### PR TITLE
Add Rock Tomb, Buff Rock Throw

### DIFF
--- a/constants/move_constants.asm
+++ b/constants/move_constants.asm
@@ -258,6 +258,7 @@
 	const WHIRLPOOL    ; fa
 	const BEAT_UP      ; fb
 	const DRAIN_PUNCH  ; fc
+	const ROCK_TOMB    ; fd
 	
 NUM_ATTACKS EQU const_value - 1
 

--- a/data/moves/animations.asm
+++ b/data/moves/animations.asm
@@ -253,7 +253,7 @@ BattleAnimations::
 	dw BattleAnim_Whirlpool
 	dw BattleAnim_BeatUp
 	dw BattleAnim_DrainPunch
-	dw BattleAnim_253
+	dw BattleAnim_RockTomb
 	dw BattleAnim_254
 	dw BattleAnim_SweetScent2
 ; $100
@@ -281,7 +281,6 @@ BattleAnimations::
 	dw BattleAnim_HitConfusion
 
 BattleAnim_0:
-BattleAnim_252:
 BattleAnim_253:
 BattleAnim_254:
 BattleAnim_MirrorMove:
@@ -4676,6 +4675,26 @@ BattleAnim_DrainPunch:
 	anim_wait 32
 	anim_incbgeffect ANIM_BG_1C
 	anim_call BattleAnim_ShowMon_0
+	anim_ret
+
+BattleAnim_RockTomb:
+	anim_1gfx ANIM_GFX_ROCKS
+	anim_bgeffect ANIM_BG_1F, $20, $2, $0
+	anim_sound 0, 1, SFX_STRENGTH
+	anim_obj ANIM_OBJ_BIG_ROCK, 128, 64, $40
+	anim_wait 12
+	anim_sound 0, 1, SFX_STRENGTH
+	anim_obj ANIM_OBJ_BIG_ROCK, 120, 68, $30
+	anim_wait 12
+	anim_sound 0, 1, SFX_STRENGTH
+	anim_obj ANIM_OBJ_BIG_ROCK, 152, 68, $30
+	anim_wait 12
+	anim_sound 0, 1, SFX_STRENGTH
+	anim_obj ANIM_OBJ_BIG_ROCK, 144, 64, $40
+	anim_wait 12
+	anim_sound 0, 1, SFX_STRENGTH
+	anim_obj ANIM_OBJ_BIG_ROCK, 136, 68, $30
+	anim_wait 56
 	anim_ret
 
 BattleAnimSub_Drain:

--- a/data/moves/descriptions.asm
+++ b/data/moves/descriptions.asm
@@ -252,12 +252,11 @@ MoveDescriptions::
 	dw WhirlpoolDescription
 	dw BeatUpDescription
 	dw DrainPunchDescription
-	dw MoveFDDescription
+	dw RockTombDescription
 	dw MoveFEDescription
 	dw MoveFFDescription
 	dw Move00Description
 
-MoveFDDescription:
 MoveFEDescription:
 MoveFFDescription:
 Move00Description:
@@ -1270,3 +1269,7 @@ BeatUpDescription:
 DrainPunchDescription:
 	db   "Steals 1/2 of the"
 	next "damage inflicted.@"
+
+RockTombDescription:
+	db   "Drops rocks, which"
+	next "slows the foe.@"

--- a/data/moves/moves.asm
+++ b/data/moves/moves.asm
@@ -99,7 +99,7 @@ Moves:
 	move THUNDERBOLT,  EFFECT_PARALYZE_HIT,       95, ELECTRIC,     100, 15,  10
 	move THUNDER_WAVE, EFFECT_PARALYZE,            0, ELECTRIC,      90, 20,   0
 	move THUNDER,      EFFECT_THUNDER,           120, ELECTRIC,      70, 10,  30
-	move ROCK_THROW,   EFFECT_NORMAL_HIT,         50, ROCK,          90, 15,   0
+	move ROCK_THROW,   EFFECT_NORMAL_HIT,         50, ROCK,         100, 20,   0
 	move EARTHQUAKE,   EFFECT_EARTHQUAKE,        100, GROUND,       100, 10,   0
 	move LAVA_PLUME,   EFFECT_BURN_HIT,           75, FIRE,         100, 15,  30
 	move DIG,          EFFECT_FLY,               100, GROUND,       100, 10,   0
@@ -264,3 +264,4 @@ Moves:
 	move WHIRLPOOL,    EFFECT_PRIORITY_HIT,       50, WATER,        100, 10,   0
 	move BEAT_UP,      EFFECT_BEAT_UP,            80, DARK,         100, 15,  20
 	move DRAIN_PUNCH,  EFFECT_LEECH_HIT,          60, FIGHTING,     100, 15,   0
+	move ROCK_TOMB,    EFFECT_SPEED_DOWN_HIT,     60, ROCK,         90, 15,  100

--- a/data/moves/moves.asm
+++ b/data/moves/moves.asm
@@ -133,8 +133,8 @@ Moves:
 	move MIRROR_MOVE,  EFFECT_MIRROR_MOVE,         0, FLYING,       100, 20,   0
 	move SELFDESTRUCT, EFFECT_SELFDESTRUCT,      200, NORMAL,       100,  1,   0
 	move EGG_BOMB,     EFFECT_BURN_HIT,          100, FIRE,          75, 10,  30
-	move LICK,         EFFECT_PARALYZE_HIT,       20, GHOST,         95, 15,  50
-	move SMOG,         EFFECT_POISON_HIT,         20, POISON,        95, 15,  50
+	move LICK,         EFFECT_PARALYZE_HIT,       20, GHOST,         95, 20,  50
+	move SMOG,         EFFECT_POISON_HIT,         20, POISON,        95, 20,  50
 	move SLUDGE,       EFFECT_POISON_HIT,         65, POISON,       100, 20,  30
 	move BONE_CLUB,    EFFECT_MULTI_HIT,          30, GROUND,        85, 10,   0
 	move FIRE_BLAST,   EFFECT_BURN_HIT,          120, FIRE,          85,  5,  10

--- a/data/moves/moves.asm
+++ b/data/moves/moves.asm
@@ -14,9 +14,9 @@ Moves:
 ; entries correspond to constants/move_constants.asm
 	move POUND,        EFFECT_NORMAL_HIT,         40, NORMAL,       100, 35,   0
 	move KARATE_CHOP,  EFFECT_NORMAL_HIT,         50, FIGHTING,     100, 25,   0
-	move DOUBLESLAP,   EFFECT_DOUBLE_HIT,         40, NORMAL,        85, 10,   0
+	move DOUBLESLAP,   EFFECT_DOUBLE_HIT,         40, NORMAL,        85, 20,   0
 	move COMET_PUNCH,  EFFECT_MULTI_HIT,          18, BUG,           85, 15,   0
-	move MEGA_PUNCH,   EFFECT_FLINCH_HIT,        100, NORMAL,        90, 10,  30
+	move MEGA_PUNCH,   EFFECT_FLINCH_HIT,        100, NORMAL,        90, 15,  30
 	move PAY_DAY,      EFFECT_PAY_DAY,            40, NORMAL,       100, 20,   0
 	move FIRE_PUNCH,   EFFECT_BURN_HIT,           75, FIRE,         100, 15,  10
 	move ICE_PUNCH,    EFFECT_FREEZE_HIT,         75, ICE,          100, 15,  10
@@ -26,19 +26,19 @@ Moves:
 	move WILL_O_WISP,  EFFECT_BURN,                0, FIRE,          85, 15,   0
 	move AIR_CUTTER,   EFFECT_GUST,               70, FLYING,        95, 15,   0
 	move SWORDS_DANCE, EFFECT_ATTACK_UP_2,         0, NORMAL,       100, 30,   0
-	move CUT,          EFFECT_FLINCH_HIT,         60, BUG,           95, 10,  20
+	move CUT,          EFFECT_FLINCH_HIT,         60, BUG,           95, 15,  20
 	move GUST,         EFFECT_GUST,               40, FLYING,       100, 35,   0
 	move WING_ATTACK,  EFFECT_NORMAL_HIT,         60, FLYING,       100, 35,   0
 	move WHIRLWIND,    EFFECT_FORCE_SWITCH,        0, FLYING,       100, 20,   0
 	move FLY,          EFFECT_FLY,                80, FLYING,        95, 15,   0
 	move BIND,         EFFECT_EVASION_DOWN_HIT,   60, ROCK,          95, 15,  75
-	move SLAM,         EFFECT_PARALYZE_HIT,      100, NORMAL,        90, 10,  30
+	move SLAM,         EFFECT_PARALYZE_HIT,      100, NORMAL,        90, 15,  30
 	move VINE_WHIP,    EFFECT_NORMAL_HIT,         45, GRASS,        100, 25,   0
 	move STOMP,        EFFECT_STOMP,              65, NORMAL,       100, 20,  30
 	move DOUBLE_KICK,  EFFECT_DOUBLE_HIT,         30, FIGHTING,     100, 30,   0
 	move MEGA_KICK,    EFFECT_NORMAL_HIT,        175, NORMAL,        75,  1,   0
 	move JUMP_KICK,    EFFECT_JUMP_KICK,          70, FIGHTING,      95, 25,   0
-	move ROLLING_KICK, EFFECT_FLINCH_HIT,         60, FIGHTING,     100, 10,  30
+	move ROLLING_KICK, EFFECT_FLINCH_HIT,         60, FIGHTING,     100, 15,  30
 	move SAND_ATTACK,  EFFECT_ACCURACY_DOWN,       0, GROUND,       100, 15,   0
 	move HEADBUTT,     EFFECT_FLINCH_HIT,         70, NORMAL,       100, 15,  30
 	move HORN_ATTACK,  EFFECT_POISON_HIT,         65, POISON,       100, 25,  10
@@ -52,7 +52,7 @@ Moves:
 	move DOUBLE_EDGE,  EFFECT_RECOIL_HIT,        120, NORMAL,       100, 15,   0
 	move TAIL_WHIP,    EFFECT_DEFENSE_DOWN,        0, NORMAL,       100, 30,   0
 	move POISON_STING, EFFECT_POISON_HIT,         25, POISON,       100, 35,  30
-	move TWINEEDLE,    EFFECT_POISON_MULTI_HIT,   40, BUG,           90, 10,  20
+	move TWINEEDLE,    EFFECT_POISON_MULTI_HIT,   40, BUG,          100, 10,  20
 	move PIN_MISSILE,  EFFECT_MULTI_HIT,          15, BUG,          100, 15,   0
 	move LEER,         EFFECT_DEFENSE_DOWN,        0, NORMAL,       100, 30,   0
 	move BITE,         EFFECT_FLINCH_HIT,         60, DARK,         100, 25,  10
@@ -133,8 +133,8 @@ Moves:
 	move MIRROR_MOVE,  EFFECT_MIRROR_MOVE,         0, FLYING,       100, 20,   0
 	move SELFDESTRUCT, EFFECT_SELFDESTRUCT,      200, NORMAL,       100,  1,   0
 	move EGG_BOMB,     EFFECT_BURN_HIT,          100, FIRE,          75, 10,  30
-	move LICK,         EFFECT_PARALYZE_HIT,       20, GHOST,         95, 10,  50
-	move SMOG,         EFFECT_POISON_HIT,         20, POISON,        95, 10,  50
+	move LICK,         EFFECT_PARALYZE_HIT,       20, GHOST,         95, 15,  50
+	move SMOG,         EFFECT_POISON_HIT,         20, POISON,        95, 15,  50
 	move SLUDGE,       EFFECT_POISON_HIT,         65, POISON,       100, 20,  30
 	move BONE_CLUB,    EFFECT_MULTI_HIT,          30, GROUND,        85, 10,   0
 	move FIRE_BLAST,   EFFECT_BURN_HIT,          120, FIRE,          85,  5,  10
@@ -152,12 +152,12 @@ Moves:
 	move DREAM_EATER,  EFFECT_DREAM_EATER,       100, PSYCHIC_TYPE, 100, 15,   0
 	move POISON_GAS,   EFFECT_TOXIC,               0, POISON,       100,  5,   0
 	move BARRAGE,      EFFECT_FALSE_SWIPE,       140, FIRE,          90,  5,   0
-	move LEECH_LIFE,   EFFECT_LEECH_HIT,          60, BUG,          100, 10,   0
+	move LEECH_LIFE,   EFFECT_LEECH_HIT,          60, BUG,          100, 15,   0
 	move LOVELY_KISS,  EFFECT_SLEEP,               0, NORMAL,        85, 10,   0
 	move SKY_ATTACK,   EFFECT_SKY_ATTACK,        140, FLYING,        95,  5,  30
 	move TRANSFORM,    EFFECT_TRANSFORM,           0, NORMAL,       100, 10,   0
 	move BUBBLE,       EFFECT_SPEED_DOWN_HIT,     30, WATER,        100, 30,  10
-	move DIZZY_PUNCH,  EFFECT_CONFUSE_HIT,        85, NORMAL,       100, 10,  30
+	move DIZZY_PUNCH,  EFFECT_CONFUSE_HIT,        85, NORMAL,       100, 15,  30
 	move SPORE,        EFFECT_POWDER_SLEEP,        0, GRASS,        100, 15,   0
 	move FLASH,        EFFECT_ACCURACY_DOWN,       0, NORMAL,        95, 10,   0
 	move PSYWAVE,      EFFECT_PSYWAVE,             1, PSYCHIC_TYPE, 100, 10,   0
@@ -192,7 +192,7 @@ Moves:
 	move COTTON_SPORE, EFFECT_ALL_UP_HIT,         60, GRASS,        100, 10,  10
 	move REVERSAL,     EFFECT_REVERSAL,            1, FIGHTING,     100, 15,   0
 	move SPITE,        EFFECT_SPITE,               0, GHOST,        100, 10,   0
-	move POWDER_SNOW,  EFFECT_FREEZE_HIT,         40, ICE,          100, 10,  20
+	move POWDER_SNOW,  EFFECT_FREEZE_HIT,         40, ICE,          100, 20,  20
 	move PROTECT,      EFFECT_PROTECT,             0, NORMAL,       100, 10,   0
 	move MACH_PUNCH,   EFFECT_PRIORITY_HIT,       40, FIGHTING,     100, 15,   0
 	move SCARY_FACE,   EFFECT_SPEED_DOWN_2,        0, NORMAL,       100, 10,   0
@@ -200,8 +200,8 @@ Moves:
 	move SWEET_KISS,   EFFECT_CONFUSE,             0, NORMAL,       100, 10,   0
 	move BELLY_DRUM,   EFFECT_BELLY_DRUM,          0, NORMAL,       100, 10,   0
 	move SLUDGE_BOMB,  EFFECT_POISON_HIT,         90, POISON,       100, 10,  30
-	move MUD_SLAP,     EFFECT_ACCURACY_DOWN_HIT,  30, GROUND,       100, 15, 100
-	move OCTAZOOKA,    EFFECT_ACCURACY_DOWN_HIT,  65, DARK,         100, 10,  50
+	move MUD_SLAP,     EFFECT_ACCURACY_DOWN_HIT,  30, GROUND,       100, 20, 100
+	move OCTAZOOKA,    EFFECT_ACCURACY_DOWN_HIT,  65, DARK,         100, 15,  50
 	move SPIKES,       EFFECT_SPIKES,              0, GROUND,       100, 20,   0
 	move ZAP_CANNON,   EFFECT_PARALYZE_HIT,      100, ELECTRIC,      50,  5, 100
 	move FORESIGHT,    EFFECT_FORESIGHT,           0, NORMAL,       100, 40,   0
@@ -264,4 +264,4 @@ Moves:
 	move WHIRLPOOL,    EFFECT_PRIORITY_HIT,       50, WATER,        100, 10,   0
 	move BEAT_UP,      EFFECT_BEAT_UP,            80, DARK,         100, 15,  20
 	move DRAIN_PUNCH,  EFFECT_LEECH_HIT,          60, FIGHTING,     100, 15,   0
-	move ROCK_TOMB,    EFFECT_SPEED_DOWN_HIT,     60, ROCK,         90, 15,  100
+	move ROCK_TOMB,    EFFECT_SPEED_DOWN_HIT,     60, ROCK,          90, 15,  50

--- a/data/moves/names.asm
+++ b/data/moves/names.asm
@@ -251,3 +251,4 @@ MoveNames::
 	db "WHIRLPOOL@"
 	db "BEAT UP@"
 	db "DRAIN PUNCH@"
+	db "ROCK TOMB@"


### PR DESCRIPTION
Added Rock Tomb as a net new move:

- Power 60
- Accuracy 90
- PP 15
- 50% chance to lower foe's speed

I buffed Rock Throw to compensate:

- Accuracy:  90 -> 100
- PP:  15 -> 20

I buffed the PP of several moves:

- Doubleslap:  10 -> 20
- Mega Punch:  10 -> 15
- Cut:  10 -> 15
- Slam:  10 -> 15
- Rolling Kick:  10 -> 15
- Lick:  10 -> 20
- Smog:  10 -> 20
- Leech Life:  10 -> 15
- Dizzy Punch:  10 -> 15
- Powder Snow:  10 -> 20
- Mud Slap:  15 -> 20
- Octazooka:  10 -> 15

And I buffed the accuracy of Twineedle from 90 to 100.