### PR TITLE
Add Glacial Slam, Update Icy Wind Animation, and Change Some Moves

### DIFF
--- a/constants/move_constants.asm
+++ b/constants/move_constants.asm
@@ -259,6 +259,7 @@
 	const BEAT_UP      ; fb
 	const DRAIN_PUNCH  ; fc
 	const ROCK_TOMB    ; fd
+	const GLACIAL_SLAM ; fe
 	
 NUM_ATTACKS EQU const_value - 1
 

--- a/data/moves/animations.asm
+++ b/data/moves/animations.asm
@@ -254,7 +254,7 @@ BattleAnimations::
 	dw BattleAnim_BeatUp
 	dw BattleAnim_DrainPunch
 	dw BattleAnim_RockTomb
-	dw BattleAnim_254
+	dw BattleAnim_GlacialSlam
 	dw BattleAnim_SweetScent2
 ; $100
 	dw BattleAnim_ThrowPokeBall
@@ -281,8 +281,6 @@ BattleAnimations::
 	dw BattleAnim_HitConfusion
 
 BattleAnim_0:
-BattleAnim_253:
-BattleAnim_254:
 BattleAnim_MirrorMove:
 	anim_ret
 
@@ -3644,30 +3642,20 @@ BattleAnim_PerishSong:
 	anim_ret
 
 BattleAnim_IcyWind:
-	anim_1gfx ANIM_GFX_SPEED
-	anim_bgeffect ANIM_BG_06, $0, $2, $0
-	anim_bgeffect ANIM_BG_ALTERNATE_HUES, $0, $2, $0
-	anim_battlergfx_1row
-	anim_sound 0, 0, SFX_PSYCHIC
-.loop
-	anim_wait 8
-	anim_obj ANIM_OBJ_AE, 64, 88, $4
-	anim_wait 8
-	anim_obj ANIM_OBJ_AE, 64, 80, $4
-	anim_wait 8
-	anim_obj ANIM_OBJ_AE, 64, 96, $4
-	anim_wait 8
-	anim_loop 2, .loop
-	anim_wait 16
-	anim_bgeffect ANIM_BG_BATTLEROBJ_2ROW, $0, $1, $0
-	anim_wait 6
-	anim_bgeffect ANIM_BG_NIGHT_SHADE, $0, $0, $8
-	anim_wait 64
-	anim_incbgeffect ANIM_BG_NIGHT_SHADE
-	anim_bgeffect ANIM_BG_SHOW_MON, $0, $1, $0
-	anim_wait 4
-	anim_incobj 7
-	anim_wait 1
+	anim_1gfx ANIM_GFX_ICE
+	anim_sound 6, 2, SFX_SHINE
+	anim_obj ANIM_OBJ_BLIZZARD, 64, 88, $23
+	anim_wait 2
+	anim_sound 6, 2, SFX_SHINE
+	anim_obj ANIM_OBJ_BLIZZARD, 64, 80, $24
+	anim_wait 2
+	anim_sound 6, 2, SFX_SHINE
+	anim_obj ANIM_OBJ_BLIZZARD, 64, 96, $23
+	anim_wait 2
+	anim_bgeffect ANIM_BG_WHITE_HUES, $0, $8, $0
+	anim_wait 40
+	anim_call BattleAnimSub_Ice
+	anim_wait 32
 	anim_ret
 
 BattleAnim_Detect:
@@ -4695,6 +4683,42 @@ BattleAnim_RockTomb:
 	anim_sound 0, 1, SFX_STRENGTH
 	anim_obj ANIM_OBJ_BIG_ROCK, 136, 68, $30
 	anim_wait 56
+	anim_ret
+
+BattleAnim_GlacialSlam:
+	anim_2gfx ANIM_GFX_ICE, ANIM_GFX_HIT
+	anim_bgeffect ANIM_BG_WHITE_HUES, $0, $8, $0
+	anim_sound 0, 1, SFX_SHINE
+	anim_obj ANIM_OBJ_12, 42, 76, $0
+	anim_wait 6
+	anim_sound 0, 1, SFX_SHINE
+	anim_obj ANIM_OBJ_12, 58, 104, $0
+	anim_wait 6
+	anim_sound 0, 1, SFX_SHINE
+	anim_obj ANIM_OBJ_12, 34, 90, $0
+	anim_wait 6
+	anim_sound 0, 1, SFX_SHINE
+	anim_obj ANIM_OBJ_12, 66, 90, $0
+	anim_wait 6
+	anim_sound 0, 1, SFX_SHINE
+	anim_obj ANIM_OBJ_12, 58, 76, $0
+	anim_wait 6
+	anim_sound 0, 1, SFX_SHINE
+	anim_obj ANIM_OBJ_12, 42, 104, $0
+	anim_wait 28
+	anim_incbgeffect ANIM_BG_WHITE_HUES
+	anim_call BattleAnim_TargetObj_1Row
+	anim_bgeffect ANIM_BG_TACKLE, $0, $1, $0
+	anim_wait 3
+	anim_sound 0, 1, SFX_TACKLE
+	anim_bgeffect ANIM_BG_FLASH_INVERTED, $0, $4, $2
+	anim_obj ANIM_OBJ_01, 128, 56, $0
+	anim_wait 6
+	anim_sound 0, 1, SFX_TACKLE
+	anim_bgeffect ANIM_BG_FLASH_INVERTED, $0, $4, $2
+	anim_obj ANIM_OBJ_01, 144, 48, $0
+	anim_wait 3
+	anim_call BattleAnim_ShowMon_0
 	anim_ret
 
 BattleAnimSub_Drain:

--- a/data/moves/descriptions.asm
+++ b/data/moves/descriptions.asm
@@ -253,11 +253,10 @@ MoveDescriptions::
 	dw BeatUpDescription
 	dw DrainPunchDescription
 	dw RockTombDescription
-	dw MoveFEDescription
+	dw GlacialSlamDescription
 	dw MoveFFDescription
 	dw Move00Description
 
-MoveFEDescription:
 MoveFFDescription:
 Move00Description:
 	db "?@"
@@ -1273,3 +1272,7 @@ DrainPunchDescription:
 RockTombDescription:
 	db   "Drops rocks, which"
 	next "slows the foe.@"
+
+GlacialSlamDescription:
+	db   "An icy tackle that"
+	next "hurts the user."

--- a/data/moves/moves.asm
+++ b/data/moves/moves.asm
@@ -133,8 +133,8 @@ Moves:
 	move MIRROR_MOVE,  EFFECT_MIRROR_MOVE,         0, FLYING,       100, 20,   0
 	move SELFDESTRUCT, EFFECT_SELFDESTRUCT,      200, NORMAL,       100,  1,   0
 	move EGG_BOMB,     EFFECT_BURN_HIT,          100, FIRE,          75, 10,  30
-	move LICK,         EFFECT_PARALYZE_HIT,       20, GHOST,         95, 20,  50
-	move SMOG,         EFFECT_POISON_HIT,         20, POISON,        95, 20,  50
+	move LICK,         EFFECT_PARALYZE_HIT,       25, GHOST,        100, 20,  50
+	move SMOG,         EFFECT_POISON_HIT,         25, POISON,       100, 20,  50
 	move SLUDGE,       EFFECT_POISON_HIT,         65, POISON,       100, 20,  30
 	move BONE_CLUB,    EFFECT_MULTI_HIT,          30, GROUND,        85, 10,   0
 	move FIRE_BLAST,   EFFECT_BURN_HIT,          120, FIRE,          85,  5,  10
@@ -207,7 +207,7 @@ Moves:
 	move FORESIGHT,    EFFECT_FORESIGHT,           0, NORMAL,       100, 40,   0
 	move DESTINY_BOND, EFFECT_DESTINY_BOND,        0, GHOST,        100,  5,   0
 	move PERISH_SONG,  EFFECT_PERISH_SONG,         0, NORMAL,       100,  5,   0
-	move ICY_WIND,     EFFECT_SPEED_DOWN_HIT,     55, ICE,           95, 15, 100
+	move ICY_WIND,     EFFECT_SPEED_DOWN_HIT,     60, ICE,           90, 15, 100
 	move DETECT,       EFFECT_PROTECT,             0, FIGHTING,     100, 20,   0
 	move BONE_RUSH,    EFFECT_PRIORITY_HIT,       60, GROUND,        90, 15,   0
 	move LOCK_ON,      EFFECT_LOCK_ON,             0, NORMAL,       100,  5,   0
@@ -264,4 +264,5 @@ Moves:
 	move WHIRLPOOL,    EFFECT_PRIORITY_HIT,       50, WATER,        100, 10,   0
 	move BEAT_UP,      EFFECT_BEAT_UP,            80, DARK,         100, 15,  20
 	move DRAIN_PUNCH,  EFFECT_LEECH_HIT,          60, FIGHTING,     100, 15,   0
-	move ROCK_TOMB,    EFFECT_SPEED_DOWN_HIT,     60, ROCK,          90, 15,  50
+	move ROCK_TOMB,    EFFECT_SPEED_DOWN_HIT,     60, ROCK,          90, 15, 100
+	move GLACIAL_SLAM, EFFECT_RECOIL_HIT,        100, ICE,          100, 15,   0

--- a/data/moves/names.asm
+++ b/data/moves/names.asm
@@ -252,3 +252,4 @@ MoveNames::
 	db "BEAT UP@"
 	db "DRAIN PUNCH@"
 	db "ROCK TOMB@"
+	db "GLACIAL SLAM@"


### PR DESCRIPTION
Added Glacial Slam as a new Ice move:

- 100 Power
- 100 Accuracy
- 15 PP
- Recoil hit

I updated Icy Wind's animation to make sense (it was some weird set of stars and used Psychic's background and sound effects).  It's a combination of Powder Snow and Blizzard.

I adjusted the following moves:

- Lick:  Power to 25 and Accuracy to 100
- Smog:  Power to 25 and Accuracy to 100
- Icy Wind:  Power to 60 and Accuracy to 90
- Rock Tomb:  Chance to lower speed up to 100% (it and Icy Wind are now essentially the same)